### PR TITLE
fix typo for short remove link command

### DIFF
--- a/docker-quick-ref.latex
+++ b/docker-quick-ref.latex
@@ -904,7 +904,7 @@
     {Force the removal of a running container (uses SIGKILL)}
 
     \mSubCmdRow
-    {-f, --link}
+    {-l, --link}
     {}
     {Remove the specified link and not the underlying container}
 


### PR DESCRIPTION
Command is `rm -l` or `rm --link` to remove links.

And thanks for this! super useful and nicely laid out
